### PR TITLE
Version 1.4.6

### DIFF
--- a/assets/css/note.css
+++ b/assets/css/note.css
@@ -10,68 +10,14 @@
  * We've used Janneke Van Dorpe's stylesheet as a base and modified it to suit our needs.
  */
 
+/* TODO: Remove unused CSS */
+
 .mce-placeholder, .note-placeholder {
 	opacity: 0.5;
 }
 
-.dashicons,
-.dashicons-before:before {
-	display: inline-block;
-	width: 20px;
-	height: 20px;
-	font-size: 20px;
-	line-height: 1;
-	font-family: "dashicons";
-	text-decoration: inherit;
-	font-weight: normal;
-	font-style: normal;
-	vertical-align: top;
-	text-align: center;
-	color: inherit;
-	-webkit-transition: color .1s ease-in 0s;
-	transition: color .1s ease-in 0s;
-	-webkit-font-smoothing: antialiased;
-	-moz-osx-font-smoothing: grayscale;
-}
-
-.button-large .dashicons,
-.button-large .dashicons-before:before {
-	height: 26px;
-	line-height: 26px;
-}
-
-/* Content */
-.notification-dialog {
-	position: fixed;
-	top: 30%;
-	left: 50%;
-	width: 450px;
-	margin-left: -225px;
-	background: #fff;
-	line-height: 1.5;
-	z-index: 1000005;
-}
-
-.notification-dialog-background {
-	position: fixed;
-	top: 0;
-	left: 0;
-	right: 0;
-	bottom: 0;
-	background: #000;
-	opacity: 0.5;
-	filter: alpha(opacity=50);
-	z-index: 1000000;
-}
-
 .hidden {
 	display: none;
-}
-
-.wp-core-ui div.updated,
-.wp-core-ui div.error {
-	padding: 0 20px 0 0.6em;
-	margin: 5px 15px 2px;
 }
 
 .wp-core-ui .button,
@@ -87,7 +33,8 @@
 	outline: none;
 }
 
-.media-frame .uploader-inline *, .media-frame .uploader-window * {
+.media-frame .uploader-inline *,
+.media-frame .uploader-window * {
 	text-align: center;
 }
 
@@ -188,16 +135,7 @@ div.mce-insert.open .dashicons {
 	transition: all 0.2s;
 }
 
-div.mce-insert-panel .mce-ico {
-	width: 20px;
-	height: 20px;
-	font-size: 20px;
-	line-height: 20px;
-	text-align: center;
-	display: block;
-	text-shadow: none;
-	margin: 0 auto;
-}
+
 
 div.mce-media-insert-panel .mce-panel {
 	background: transparent;
@@ -211,19 +149,6 @@ div.mce-media-insert-panel .mce-ico {
 	line-height: 100px;
 }
 
-div.mce-insert-panel .mce-btn {
-	border: 1px solid transparent;
-	position: relative;
-	display: inline-block;
-	background: none;
-	border-radius: 2px;
-	box-shadow: none;
-	margin: 2px;
-	color: #777;
-	height: 24px;
-	line-height: 24px;
-}
-
 div.mce-media-insert-panel .mce-btn {
 	height: 100px;
 	line-height: 64px;
@@ -233,91 +158,10 @@ div.mce-media-insert-panel .mce-btn {
 	left: 50%;
 }
 
-div.mce-insert-panel .mce-btn:hover,
-div.mce-insert-panel .mce-btn:focus {
-	color: #222;
-	background-color: #fafafa;
-	border-color: #999;
-	-webkit-box-shadow: inset 0 1px 0 #fff, 0 1px 0 rgba( 0, 0, 0, 0.08 );
-	box-shadow: inset 0 1px 0 #fff, 0 1px 0 rgba( 0, 0, 0, 0.08 );
-}
-
-
-div.mce-insert-panel .mce-btn.mce-active,
-div.mce-insert-panel .mce-btn:active {
-	background-color: #ebebeb;
-	border-color: #999;
-	-webkit-box-shadow: inset 0 2px 5px -3px rgba( 0, 0, 0, 0.3 );
-	box-shadow: inset 0 2px 5px -3px rgba( 0, 0, 0, 0.3 );
-}
-
-div.mce-insert-panel .mce-btn.mce-active:hover {
-	border-color: #555;
-}
-
-div.mce-insert-panel .mce-btn button {
-	padding: 2px 3px;
-	font-size: 14px;
-	font-weight: bold;
-	line-height: 20px;
-	cursor: pointer;
-	color: #777;
-	text-align: center;
-	overflow: visible;
-	-webkit-appearance: none;
-	display: block;
-	-moz-box-sizing: border-box;
-	-webkit-box-sizing: border-box;
-	box-sizing: border-box;
-}
-
-div.mce-insert-panel .mce-btn button i {
-	line-height: 20px;
-}
-
 div.mce-media-insert-panel .mce-btn button i {
 	line-height: 100px;
 }
 
-div.mce-insert-panel .mce-btn.mce-disabled:not(:focus),
-div.mce-panel .mce-menu-item.mce-disabled:not(:focus) {
-	position: absolute;
-	margin: -1px;
-	padding: 0;
-	height: 1px;
-	width: 1px;
-	overflow: hidden;
-	clip: rect(0 0 0 0);
-	border: 0;
-}
-
-div.mce-tinymce-inline,
-div.mce-insert-panel {
-	position: absolute;
-	z-index: 9998;
-	background: #f5f5f5;
-	padding: 3px;
-	color: black;
-	margin-bottom: 8px;
-	box-shadow: 0 1px 1px rgba( 0, 0, 0, 0.04 );
-	border: 1px solid #dedede;
-	border-radius: 3px;
-	top: 0;
-	left: 0;
-	opacity: 1;
-	-moz-user-select: none;
-	-webkit-user-select: none;
-	-ms-user-select: none;
-	user-select: none;
-	-webkit-box-sizing: border-box;
-	-moz-box-sizing: border-box;
-	box-sizing: border-box;
-}
-
-div.mce-insert-panel {
-	opacity: 1;
-	background: rgba(245, 245, 245, 0.85);
-}
 
 div.mce-media-insert-panel {
 	margin: 0;
@@ -329,10 +173,6 @@ div.mce-media-insert-panel {
 	padding: 1px;
 }
 
-.mce-tinymce-inline .mce-toolbar-grp {
-	background: #f5f5f5;
-}
-
 div.mce-tinymce-inline.mce-inline-toolbar-active {
 	transition:
 		top 0.1s ease-out,
@@ -341,77 +181,9 @@ div.mce-tinymce-inline.mce-inline-toolbar-active {
 	opacity: 1;
 }
 
-div.mce-tinymce-inline:before,
-div.mce-tinymce-inline:after,
-div.mce-insert-panel:before,
-div.mce-insert-panel:after {
-	position: absolute;
-	left: 50%;
-	display: block;
-	width: 0;
-	height: 0;
-	border-style: solid;
-	border-color: transparent;
-	content: '';
-}
-
 div.mce-media-insert-panel:before,
 div.mce-media-insert-panel:after {
 	display: none;
-}
-
-div.mce-tinymce-inline.mce-arrow-up:before {
-	top: -18px;
-	border-bottom-color: #dedede;
-	border-width: 9px;
-	margin-left: -9px;
-}
-
-div.mce-tinymce-inline.mce-arrow-down:before,
-div.mce-insert-panel:before {
-	bottom: -18px;
-	border-top-color: #dedede;
-	border-width: 9px;
-	margin-left: -9px;
-}
-
-div.mce-tinymce-inline.mce-arrow-up:after {
-	top: -16px;
-	border-bottom-color: #f5f5f5;
-	border-width: 8px;
-	margin-left: -8px;
-}
-
-div.mce-tinymce-inline.mce-arrow-down:after,
-div.mce-insert-panel:after {
-	bottom: -16px;
-	border-top-color: #f5f5f5;
-	border-width: 8px;
-	margin-left: -8px;
-}
-
-div.mce-insert-panel:after {
-	border-top-color: rgba(245, 245, 245, 0.85);
-}
-
-div.mce-tinymce-inline.mce-arrow-left:before,
-div.mce-tinymce-inline.mce-arrow-left:after {
-	left: 20px;
-}
-
-div.mce-tinymce-inline.mce-arrow-right:before,
-div.mce-tinymce-inline.mce-arrow-right:after {
-	right: 11px;
-	left: auto;
-}
-
-div.mce-tinymce-inline.mce-arrow-full {
-	right: 0;
-}
-
-div.mce-tinymce-inline.mce-arrow-full > div {
-	width: 100%;
-	overflow-x: auto;
 }
 
 .mce-toolbar .mce-btn-group .mce-btn.mce-active:hover i.mce-ico {
@@ -486,7 +258,9 @@ div.mce-tinymce-inline.mce-arrow-full > div {
 }
 
 
-/* Note */
+/**
+ * Note
+ */
 .mce-note-edit-focus {
 	background: #ffa !important;
 }
@@ -500,6 +274,10 @@ div.mce-tinymce-inline.mce-arrow-full > div {
 .note-cf:after {
 	content: ' ';
 	display: table;
+}
+
+.note-hidden {
+	display: none !important;
 }
 
 /* Note Sidebars */
@@ -938,7 +716,7 @@ div.mce-tinymce-inline.mce-arrow-full > div {
 .note-media-placeholder .note-placeholder,
 .note-media-placeholder div.mce-media-insert-panel,
 .note-editor-media div.mce-media-insert-panel,
-div.mce-insert-panel.mce-note-media-insert-panel {
+div.mce-note-insert-panel.mce-note-media-insert-panel {
 	min-height: 400px;
 	background: #f6f6f6;
 	border: 2px dashed #ddd;
@@ -950,7 +728,7 @@ div.mce-insert-panel.mce-note-media-insert-panel {
 	box-sizing: border-box;
 }
 
-div.mce-insert-panel.mce-note-media-insert-panel {
+div.mce-note-insert-panel.mce-note-media-insert-panel {
 	width: 100%;
 	position: absolute;
 	top: 0;
@@ -970,4 +748,220 @@ div.mce-insert-panel.mce-note-media-insert-panel {
 	clip: rect(0 0 0 0);
 	border: 0;
 	word-wrap: normal !important;
+}
+
+
+
+
+
+
+
+
+
+
+/**
+ * Note TinyMCE
+ */
+.note-widget.note-tinymce .note-wrapper:not(.note-template-wrapper),
+.note-widget.note-tinymce .note-wrapper .note-col,
+.note-widget.note-tinymce .note-wrapper.note-template-wrapper .note-content {
+	margin: -1.5rem;
+}
+
+.note-widget.note-tinymce .note-wrapper .widget-content,
+.note-widget.note-tinymce .note-wrapper .note-col .note-content,
+.note-widget.note-tinymce .note-wrapper.note-template-wrapper,
+.note-widget.note-tinymce .note-wrapper.note-template-wrapper .note-content {
+	padding: 1.5rem;
+}
+
+.note-widget.note-tinymce .widget-content.mce-content-body {
+	line-height: inherit;
+}
+
+div.mce-panel.mce-tinymce-inline,
+div.mce-panel.note-toolbar {
+	padding: 3px;
+	background: #f5f5f5;
+	box-shadow: 0 1px 1px rgba( 0, 0, 0, 0.04 );
+	border: 1px solid #dedede;
+	border-radius: 3px;
+	-moz-user-select: none;
+	-webkit-user-select: none;
+	-ms-user-select: none;
+	user-select: none;
+	-webkit-box-sizing: border-box;
+	-moz-box-sizing: border-box;
+	box-sizing: border-box;
+}
+
+div.mce-panel.mce-tinymce-inline:not(.mce-arrow-right):not(.mce-arrow-center):not(.mce-arrow-left):not(.mce-tooltip-arrow-n):not(.mce-tooltip-arrow-s):not(.mce-tooltip-arrow-e):not(.mce-tooltip-arrow-w),
+div.mce-panel.note-toolbar:not(.mce-arrow-right):not(.mce-arrow-center):not(.mce-arrow-left):not(.mce-tooltip-arrow-n):not(.mce-tooltip-arrow-s):not(.mce-tooltip-arrow-e):not(.mce-tooltip-arrow-w) {
+	margin-top: 1.5rem;
+}
+
+div.mce-panel.mce-tinymce-inline.mce-arrow-up,
+div.mce-panel.note-toolbar.mce-arrow-up {
+	margin-top: 12px !important;
+}
+
+div.mce-panel.mce-tinymce-inline.mce-arrow-down,
+div.mce-panel.note-toolbar.mce-arrow-down {
+	margin-top: -12px !important;
+}
+
+div.mce-panel.mce-tinymce-inline .mce-toolbar .mce-ico,
+div.mce-panel.note-toolbar .mce-toolbar .mce-ico{
+	color: #555d66;
+}
+
+div.mce-panel.mce-tinymce-inline .mce-container-body,
+div.mce-panel.note-toolbar .mce-container-body {
+	margin: -1.5px;
+	padding: 3px;
+}
+
+div.mce-panel.mce-tinymce-inline .mce-btn.mce-active button,
+div.mce-panel.mce-tinymce-inline .mce-btn.mce-active:hover button,
+div.mce-panel.mce-tinymce-inline .mce-btn.mce-active i,
+div.mce-panel.mce-tinymce-inline .mce-btn.mce-active:hover i,
+div.mce-panel.note-toolbar .mce-btn.mce-active button,
+div.mce-panel.note-toolbar .mce-btn.mce-active:hover button,
+div.mce-panel.note-toolbar .mce-btn.mce-active i,
+div.mce-panel.note-toolbar .mce-btn.mce-active:hover i {
+	color: #555d66;
+}
+
+
+
+
+
+
+/**
+ * Note Insert Panel
+ */
+div.mce-panel.mce-note-insert-panel {
+	margin-bottom: -1.5rem;
+	padding: 3px;
+	color: black;
+	background: rgba(245, 245, 245, 0.85);
+	border: 1px solid #dedede;
+	border-radius: 3px;
+	box-shadow: 0 1px 1px rgba(0, 0, 0, 0.04);
+	position: absolute;
+	z-index: 9998;
+	top: 0;
+	left: 0;
+	opacity: 1;
+	-moz-user-select: none;
+	-webkit-user-select: none;
+	-ms-user-select: none;
+	user-select: none;
+	-webkit-box-sizing: border-box;
+	-moz-box-sizing: border-box;
+	box-sizing: border-box;
+}
+
+div.mce-note-insert-panel:before,
+div.mce-note-insert-panel:after {
+	position: absolute;
+	left: 50%;
+	display: block;
+	width: 0;
+	height: 0;
+	border-style: solid;
+	border-color: transparent;
+	content: '';
+}
+
+div.mce-note-insert-panel:before {
+	bottom: -18px;
+	border-top-color: #dedede;
+	border-width: 9px;
+	margin-left: -9px;
+}
+
+div.mce-note-insert-panel:after {
+	bottom: -14px;
+	border-top-color: rgba(245, 245, 245, 0.85);
+	border-width: 7px;
+	margin-left: -7px;
+}
+
+div.mce-note-insert-panel .mce-panel {
+	margin: 0;
+	max-width: none;
+	background: transparent;
+	border: none;
+	box-shadow: none;
+	position: relative;
+}
+
+div.mce-note-insert-panel .mce-toolbar .mce-btn-group > div {
+	white-space: nowrap;
+}
+
+div.mce-note-insert-panel .mce-btn {
+	border: 1px solid transparent;
+	position: relative;
+	display: inline-block;
+	background: none;
+	border-radius: 2px;
+	box-shadow: none;
+	margin: 2px;
+	color: #777;
+	height: 24px;
+	line-height: 24px;
+}
+
+div.mce-note-insert-panel .mce-ico {
+	width: 20px;
+	height: 20px;
+	font-size: 20px;
+	line-height: 20px;
+	text-align: center;
+	display: block;
+	text-shadow: none;
+	margin: 0 auto;
+}
+
+div.mce-note-insert-panel .mce-btn:hover,
+div.mce-note-insert-panel .mce-btn:focus {
+	color: #222;
+	background-color: #fafafa;
+	border-color: #999;
+	-webkit-box-shadow: inset 0 1px 0 #fff, 0 1px 0 rgba( 0, 0, 0, 0.08 );
+	box-shadow: inset 0 1px 0 #fff, 0 1px 0 rgba( 0, 0, 0, 0.08 );
+}
+
+div.mce-note-insert-panel .mce-btn.mce-active,
+div.mce-note-insert-panel .mce-btn:active {
+	background-color: #ebebeb;
+	border-color: #999;
+	-webkit-box-shadow: inset 0 2px 5px -3px rgba( 0, 0, 0, 0.3 );
+	box-shadow: inset 0 2px 5px -3px rgba( 0, 0, 0, 0.3 );
+}
+
+div.mce-note-insert-panel .mce-btn.mce-active:hover {
+	border-color: #555;
+}
+
+div.mce-note-insert-panel .mce-btn button {
+	padding: 2px 3px;
+	font-size: 14px;
+	font-weight: bold;
+	line-height: 20px;
+	cursor: pointer;
+	color: #777;
+	text-align: center;
+	overflow: visible;
+	-webkit-appearance: none;
+	display: block;
+	-moz-box-sizing: border-box;
+	-webkit-box-sizing: border-box;
+	box-sizing: border-box;
+}
+
+div.mce-note-insert-panel .mce-btn button i {
+	line-height: 20px;
 }

--- a/assets/css/widgets/note-widget.css
+++ b/assets/css/widgets/note-widget.css
@@ -31,7 +31,7 @@
 	-ms-align-content: flex-start;
 	-webkit-align-content: flex-start;
 	align-content: flex-start;
-	-ms-flex-pack: end;
+	-ms-flex-pack: start;
 	-webkit-box-sizing: border-box;
 	box-sizing: border-box;
 }

--- a/assets/js/note-customizer.js
+++ b/assets/js/note-customizer.js
@@ -106,11 +106,11 @@ var note = note || {};
 
 				// Compare the content to make sure it's actually changed
 				// TODO: Might need to account for "processing" API state here?
-				if ( widget_content_data.updateCount > 0 && data.widget.content !== widget_content_data.content ) {
+				if ( data.widget.content !== widget_content_data.content ) {
 					// Set the content value
 					$widget_content.val( data.widget.content );
 
-					// TODO: In WordPres 4.7 ensure this doesn't trigger the API save state (it may be triggered due to the add/remove class calls for customize-unpreviewable?)
+					// TODO: In WordPress 4.7 ensure this doesn't trigger the API save state (it may be triggered due to the add/remove class calls for customize-unpreviewable?)
 					// Update the API saved state (content has been updated, API data is not saved)
 					api.state( 'saved' ).set( false );
 					api.state.trigger( 'change', api.state.create( 'saved' ) ); // trigger the saved flag
@@ -867,7 +867,6 @@ var note = note || {};
 			}
 		}
 	};
-
 
 
 	/**

--- a/assets/js/note-tinymce-background.js
+++ b/assets/js/note-tinymce-background.js
@@ -67,7 +67,7 @@ tinymce.PluginManager.add( 'note_background', function( editor ) {
 	editor.addButton( 'note_background', {
 		// id: 'note_background', TODO: Not currently used; TinyMCE doesn't add the tooltips on multiple editors when this is set
 		tooltip: 'Edit Background Image', // TODO: i18n, l10n
-		icon: 'format-image dashicons-format-image',
+		icon: 'dashicon dashicons-format-image',
 		onclick: function() {
 			var library, library_comparator;
 

--- a/assets/js/note-tinymce-insert.js
+++ b/assets/js/note-tinymce-insert.js
@@ -183,7 +183,7 @@ tinymce.PluginManager.add( 'note_insert', function( editor ) {
 	// WordPress Image
 	editor.addButton( 'wp_image', {
 		tooltip: 'Image', // TODO: i18n, l10n
-		icon: 'format-image dashicons-format-image',
+		icon: 'dashicon dashicons-format-image',
 		onclick: function() {
 			var frame_menu;
 
@@ -253,7 +253,7 @@ tinymce.PluginManager.add( 'note_insert', function( editor ) {
 	// Note Edit Button
 	editor.addButton( 'note_edit', {
 		tooltip: 'Edit', // TODO: i18n, l10n
-		icon: 'edit dashicons-edit',
+		icon: 'dashicon dashicons-edit',
 		onclick: function() {
 			// Send data to the Customizer
 			wp.customize.NotePreview.preview.send( 'note-widget-edit', editor.note.widget_data );

--- a/assets/js/note-tinymce-theme.js
+++ b/assets/js/note-tinymce-theme.js
@@ -10,6 +10,8 @@
  * We've used Janneke Van Dorpe's TinyMCE theme as a base and modified it to suit our needs.
  */
 
+// TODO: Remove
+
 /* global tinymce */
 
 tinymce.ThemeManager.add( 'note', function( editor ) {
@@ -381,8 +383,8 @@ tinymce.ThemeManager.add( 'note', function( editor ) {
 		editor.on( 'selectionchange nodechange', function( event ) {
 			var element = event.element || editor.selection.getNode();
 
-			// Bail if we don't have a selection
-			if ( editor.selection.isCollapsed() ) {
+			// Bail if we have a panel and we don't have a selection
+			if ( panel && editor.selection.isCollapsed() ) {
 				// Hide the panel
 				panel.hide();
 
@@ -392,8 +394,8 @@ tinymce.ThemeManager.add( 'note', function( editor ) {
 			setTimeout( function() {
 				var content, name;
 
-				// Bail if this editor does not have focus or there is an open window
-				if ( ! focus || open_window ) {
+				// Bail if we don't have a panel, this editor does not have focus, or there is an open window
+				if ( ! panel || ! focus || open_window ) {
 					return;
 				}
 
@@ -580,7 +582,7 @@ tinymce.ThemeManager.add( 'note', function( editor ) {
 			// If this is a wp_link_cancel or wp_link_apply command
 			if ( event.command === 'wp_link_cancel' || event.command === 'wp_link_apply' ) {
 				// If the panel is visible and the editor selection is collapsed hide it (fixes bug in Firefox where selectionchange isn't triggered in some cases)
-				if ( ! WP_Link && panel.state.get( 'visible' ) && ( editor.selection.isCollapsed() || ( toolbars[wp_toolbar_names.link_edit] && toolbars[wp_toolbar_names.link_edit].state.get( 'visible' ) ) ) ) {
+				if ( panel && ! WP_Link && panel.state.get( 'visible' ) && ( editor.selection.isCollapsed() || ( toolbars[wp_toolbar_names.link_edit] && toolbars[wp_toolbar_names.link_edit].state.get( 'visible' ) ) ) ) {
 					panel.hide();
 				}
 			}
@@ -591,8 +593,11 @@ tinymce.ThemeManager.add( 'note', function( editor ) {
 			// Set the flag
 			open_window = true;
 
-			// Hide the panel
-			panel.hide();
+			// If we have a panel
+			if ( panel ) {
+				// Hide the panel
+				panel.hide();
+			}
 		} );
 
 		// Closewindow event
@@ -682,8 +687,11 @@ tinymce.ThemeManager.add( 'note', function( editor ) {
 
 		// Window resize event
 		DOM.bind( window, 'resize', function() {
-			// Hide the panel
-			panel.hide();
+			// If we have a panel
+			if ( panel ) {
+				// Hide the panel
+				panel.hide();
+			}
 		} );
 
 		return {};

--- a/changelog.txt
+++ b/changelog.txt
@@ -2,9 +2,22 @@
 Plugin: Note
 Author: Slocum Design Studio
 Author URI: https://slocumstudio.com/
-Current Version: 1.4.5
+Current Version: 1.4.6
 ==========================================
 
+
+1.4.6 // June 01 2018
+---------------------
+- Transitioned to the "inline" TinyMCE theme (TinyMCE version 4.7 moved most of the TinyMCE UI logic into the
+  theme instead of TinyMCE core)
+- Adjusted icons in Note Insert and Note Backgroud TinyMCE plugins
+- Added Note TinyMCE theme placeholder logic to the Note Placeholder TinyMCE plugin
+- Adjusted logic to load Note TinyMCE plugins (moved to "wp_print_footer_scripts" action)
+- Adjusted Note TinyMCE configuration (using insert_toolbar and selection_toolbar for "inline" TinyMCE theme,
+  removed the menubar, removed wpembed TinyMCE plugin)
+- Added logic to hide the "inlite" TinyMCE image context toolbar when an image node was selected
+- Added logic to enqueue WordPress editor styles for use in Note
+- Adjusted various Note TinyMCE CSS styles
 
 1.4.5 // June 16 2017
 ---------------------

--- a/note.php
+++ b/note.php
@@ -3,11 +3,11 @@
  * Plugin Name: Note - A live edit text widget
  * Plugin URI: http://www.conductorplugin.com/note/
  * Description: Note is a simple and easy to use widget for editing bits of text, live, in your WordPress Customizer
- * Version: 1.4.5
+ * Version: 1.4.6
  * Author: Slocum Studio
  * Author URI: http://www.slocumstudio.com/
  * Requires at least: 4.3
- * Tested up to: 4.8
+ * Tested up to: 4.9.6
  * License: GPLv2 or later
  * License URI: http://www.gnu.org/licenses/gpl-2.0.html
  *
@@ -26,7 +26,7 @@ if ( ! class_exists( 'Note' ) ) {
 		/**
 		 * @var string
 		 */
-		public static $version = '1.4.5';
+		public static $version = '1.4.6';
 
 		/**
 		 * @var Note, Instance of the class

--- a/readme.txt
+++ b/readme.txt
@@ -3,8 +3,8 @@ Contributors: slocumstudio
 Donate link: 
 Tags: note, widget, customizer, live edit, wysiwyg, text, text widget, plugin, sidebar
 Requires at least: 4.3
-Tested up to: 4.8
-Stable tag: 1.4.5
+Tested up to: 4.9.6
+Stable tag: 1.4.6
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -64,6 +64,16 @@ See the video in our [Description](https://wordpress.org/plugins/note/) for a li
 
 
 == Changelog ==
+
+= 1.4.6 // June 01 2018 =
+* Transitioned to the "inline" TinyMCE theme (TinyMCE version 4.7 moved most of the TinyMCE UI logic into the theme instead of TinyMCE core)
+* Adjusted icons in Note Insert and Note Backgroud TinyMCE plugins
+* Added Note TinyMCE theme placeholder logic to the Note Placeholder TinyMCE plugin
+* Adjusted logic to load Note TinyMCE plugins (moved to "wp_print_footer_scripts" action)
+* Adjusted Note TinyMCE configuration (using insert_toolbar and selection_toolbar for "inline" TinyMCE theme, removed the menubar, removed wpembed TinyMCE plugin)
+* Added logic to hide the "inlite" TinyMCE image context toolbar when an image node was selected
+* Added logic to enqueue WordPress editor styles for use in Note
+* Adjusted various Note TinyMCE CSS styles
 
 = 1.4.5 // June 16 2017 =
 * Fixed a bug where a possible fatal PHP error would occur when a query object did not have the is_main_query() method


### PR DESCRIPTION
- Transitioned to the "inline" TinyMCE theme (TinyMCE version 4.7 moved most of the TinyMCE UI logic into the theme instead of TinyMCE core)
- Adjusted icons in Note Insert and Note Backgroud TinyMCE plugins
- Added Note TinyMCE theme placeholder logic to the Note Placeholder TinyMCE plugin
- Adjusted logic to load Note TinyMCE plugins (moved to "wp_print_footer_scripts" action)
- Adjusted Note TinyMCE configuration (using insert_toolbar and selection_toolbar for "inline" TinyMCE theme, removed the menubar, removed wpembed TinyMCE plugin)
- Added logic to hide the "inlite" TinyMCE image context toolbar when an image node was selected
- Added logic to enqueue WordPress editor styles for use in Note
- Adjusted various Note TinyMCE CSS styles