### PR TITLE
Version 1.4.7

### DIFF
--- a/assets/css/note-customizer.css
+++ b/assets/css/note-customizer.css
@@ -1,0 +1,11 @@
+/**
+ * Note Customizer
+ */
+
+#customize-save-button-wrapper .save.note-has-next-sibling {
+	border-radius: 3px !important;
+}
+
+#customize-save-button-wrapper .save.note-has-next-sibling + #publish-settings {
+	display: none !important;
+}

--- a/assets/css/note.css
+++ b/assets/css/note.css
@@ -136,39 +136,6 @@ div.mce-insert.open .dashicons {
 }
 
 
-
-div.mce-media-insert-panel .mce-panel {
-	background: transparent;
-	border: none;
-}
-
-div.mce-media-insert-panel .mce-ico {
-	width: 100px;
-	height: 100px;
-	font-size: 60px;
-	line-height: 100px;
-}
-
-div.mce-media-insert-panel .mce-btn {
-	height: 100px;
-	line-height: 64px;
-	margin: -54px 0 0 -51px;
-	position: absolute;
-	top: 50%;
-	left: 50%;
-}
-
-div.mce-media-insert-panel .mce-btn button i {
-	line-height: 100px;
-}
-
-
-div.mce-media-insert-panel {
-	margin: 0;
-	background: transparent;
-	border: none;
-}
-
 .mce-tinymce-inline {
 	padding: 1px;
 }
@@ -179,11 +146,6 @@ div.mce-tinymce-inline.mce-inline-toolbar-active {
 		left 0.1s ease-out,
 		opacity 0.1s ease-in-out;
 	opacity: 1;
-}
-
-div.mce-media-insert-panel:before,
-div.mce-media-insert-panel:after {
-	display: none;
 }
 
 .mce-toolbar .mce-btn-group .mce-btn.mce-active:hover i.mce-ico {
@@ -713,28 +675,6 @@ div.mce-media-insert-panel:after {
 	display: none;
 }
 
-.note-media-placeholder .note-placeholder,
-.note-media-placeholder div.mce-media-insert-panel,
-.note-editor-media div.mce-media-insert-panel,
-div.mce-note-insert-panel.mce-note-media-insert-panel {
-	min-height: 400px;
-	background: #f6f6f6;
-	border: 2px dashed #ddd;
-
-	position: relative;
-
-	-webkit-box-sizing: border-box;
-	-moz-box-sizing: border-box;
-	box-sizing: border-box;
-}
-
-div.mce-note-insert-panel.mce-note-media-insert-panel {
-	width: 100%;
-	position: absolute;
-	top: 0;
-	left: 0;
-}
-
 /**
  * jQuery Autocomplete
  */
@@ -762,7 +702,8 @@ div.mce-note-insert-panel.mce-note-media-insert-panel {
 /**
  * Note TinyMCE
  */
-.note-widget.note-tinymce .note-wrapper:not(.note-template-wrapper),
+/* TODO: Adjust/Remove accordingly */
+/*.note-widget.note-tinymce .note-wrapper:not(.note-template-wrapper),
 .note-widget.note-tinymce .note-wrapper .note-col,
 .note-widget.note-tinymce .note-wrapper.note-template-wrapper .note-content {
 	margin: -1.5rem;
@@ -773,17 +714,19 @@ div.mce-note-insert-panel.mce-note-media-insert-panel {
 .note-widget.note-tinymce .note-wrapper.note-template-wrapper,
 .note-widget.note-tinymce .note-wrapper.note-template-wrapper .note-content {
 	padding: 1.5rem;
-}
+}*/
 
-.note-widget.note-tinymce .widget-content.mce-content-body {
+.note-widget.note-tinymce .widget-content.mce-content-body,
+.note-widget.note-tinymce .note-content.mce-content-body {
 	line-height: inherit;
 }
 
 div.mce-panel.mce-tinymce-inline,
 div.mce-panel.note-toolbar {
+	margin-bottom: 1rem;
 	padding: 3px;
 	background: #f5f5f5;
-	box-shadow: 0 1px 1px rgba( 0, 0, 0, 0.04 );
+	box-shadow: 0 1px 1px rgba(0, 0, 0, 0.04);
 	border: 1px solid #dedede;
 	border-radius: 3px;
 	-moz-user-select: none;
@@ -795,7 +738,8 @@ div.mce-panel.note-toolbar {
 	box-sizing: border-box;
 }
 
-div.mce-panel.mce-tinymce-inline:not(.mce-arrow-right):not(.mce-arrow-center):not(.mce-arrow-left):not(.mce-tooltip-arrow-n):not(.mce-tooltip-arrow-s):not(.mce-tooltip-arrow-e):not(.mce-tooltip-arrow-w),
+/* TODO: Adjust/Remove accordingly */
+/*div.mce-panel.mce-tinymce-inline:not(.mce-arrow-right):not(.mce-arrow-center):not(.mce-arrow-left):not(.mce-tooltip-arrow-n):not(.mce-tooltip-arrow-s):not(.mce-tooltip-arrow-e):not(.mce-tooltip-arrow-w),
 div.mce-panel.note-toolbar:not(.mce-arrow-right):not(.mce-arrow-center):not(.mce-arrow-left):not(.mce-tooltip-arrow-n):not(.mce-tooltip-arrow-s):not(.mce-tooltip-arrow-e):not(.mce-tooltip-arrow-w) {
 	margin-top: 1.5rem;
 }
@@ -808,10 +752,10 @@ div.mce-panel.note-toolbar.mce-arrow-up {
 div.mce-panel.mce-tinymce-inline.mce-arrow-down,
 div.mce-panel.note-toolbar.mce-arrow-down {
 	margin-top: -12px !important;
-}
+}*/
 
 div.mce-panel.mce-tinymce-inline .mce-toolbar .mce-ico,
-div.mce-panel.note-toolbar .mce-toolbar .mce-ico{
+div.mce-panel.note-toolbar .mce-toolbar .mce-ico {
 	color: #555d66;
 }
 
@@ -841,10 +785,10 @@ div.mce-panel.note-toolbar .mce-btn.mce-active:hover i {
  * Note Insert Panel
  */
 div.mce-panel.mce-note-insert-panel {
-	margin-bottom: -1.5rem;
+	margin-bottom: 1rem;
 	padding: 3px;
 	color: black;
-	background: rgba(245, 245, 245, 0.85);
+	background: rgba(245, 245, 245, 0.90);
 	border: 1px solid #dedede;
 	border-radius: 3px;
 	box-shadow: 0 1px 1px rgba(0, 0, 0, 0.04);
@@ -964,4 +908,90 @@ div.mce-note-insert-panel .mce-btn button {
 
 div.mce-note-insert-panel .mce-btn button i {
 	line-height: 20px;
+}
+
+
+/**
+ * Note Media Insert Panel
+ */
+div.mce-note-insert-panel.mce-note-media-insert-panel {
+	width: 100%;
+	min-height: 400px;
+	margin: auto;
+	background: #f6f6f6;
+	border: 2px dashed #ddd;
+	display: -webkit-box;
+	display: -moz-box;
+	display: -ms-flexbox;
+	display: -webkit-flex;
+	display: flex;
+	-moz-flex-flow: row wrap;
+	-ms-flex-flow: row wrap;
+	-webkit-flex-flow: row wrap;
+	flex-flow: row wrap;
+	-moz-justify-content: space-around;
+	-ms-justify-content: space-around;
+	-webkit-justify-content: space-around;
+	justify-content: space-around;
+	-moz-align-content: flex-start;
+	-ms-align-content: flex-start;
+	-webkit-align-content: flex-start;
+	align-content: flex-start;
+	-ms-flex-pack: start;
+	-webkit-box-sizing: border-box;
+	box-sizing: border-box;
+	position: relative;
+}
+
+div.mce-note-insert-panel.mce-note-media-insert-panel .mce-container-body {
+	width: 100%;
+}
+
+div.mce-note-insert-panel.mce-note-media-insert-panel .mce-container-body .mce-toolbar-grp,
+div.mce-note-insert-panel.mce-note-media-insert-panel .mce-container-body .mce-container,
+div.mce-note-insert-panel.mce-note-media-insert-panel .mce-container-body .mce-container > div,
+div.mce-note-insert-panel.mce-note-media-insert-panel .mce-container-body .mce-container-body {
+	width: 100%;
+	height: 100%;
+	margin: 0;
+	padding: 0;
+}
+
+div.mce-note-insert-panel.mce-note-media-insert-panel:before,
+div.mce-note-insert-panel.mce-note-media-insert-panel:after {
+	display: none;
+}
+
+div.mce-note-insert-panel.mce-note-media-insert-panel .mce-panel {
+	background: transparent;
+	border: none;
+}
+
+div.mce-note-insert-panel.mce-note-media-insert-panel .mce-btn {
+	width: 100%;
+	height: 100%;
+	margin: 0;
+
+	-webkit-box-sizing: border-box;
+	box-sizing: border-box;
+}
+
+div.mce-note-insert-panel.mce-note-media-insert-panel .mce-btn button {
+	height: 100px;
+	margin: -54px 0 0 -51px;
+	line-height: 64px;
+	position: absolute;
+	top: 50%;
+	left: 50%;
+}
+
+div.mce-note-insert-panel.mce-note-media-insert-panel .mce-btn button i {
+	line-height: 100px;
+}
+
+div.mce-note-insert-panel.mce-note-media-insert-panel .mce-ico {
+	width: 100px;
+	height: 100px;
+	font-size: 60px;
+	line-height: 100px;
 }

--- a/assets/js/note.js
+++ b/assets/js/note.js
@@ -40,6 +40,7 @@
 		$note_widgets: false,
 		$document: false,
         $body: false,
+		total_note_widget_update_count: 0,
 		transition_duration: 400, // CSS transition is 400ms
 		// Initialization
 		init: function () {
@@ -94,11 +95,10 @@
 
 				// Listen for the "note-widget-edit" event from the Customizer
 				self.preview.bind( 'note-widget-edit', function( data ) {
-					// Find the correct editor
 					var editor = _.find( self.editors, function( editor ) {
-						// TODO: Check hasOwnProperty()
-						return editor.note.widget_data.widget.id === data.widget.id;
-					} ),
+							// TODO: Check hasOwnProperty()
+							return editor.note.widget_data.widget.id === data.widget.id;
+						} ),
 						body = ( editor ) ? editor.getBody() : false,
 						$body = ( body ) ? $( body ) : false,
 						$note_wrapper = ( body ) ? $body.parents( '.note-wrapper' ) : false,
@@ -111,7 +111,7 @@
 						window_bottom;
 
 					// Note Template Widgets (Note Widgets that have a template selected; possibly rows/columns)
-					if ( editor && $note_wrapper.length && $note_wrapper.hasClass( 'note-template-wrapper' ) ) {
+					if ( ! editor && $note_wrapper.length && $note_wrapper.hasClass( 'note-template-wrapper' ) ) {
 						// Loop through editors
 						$note_wrapper.find( '.editor' ).each( function() {
 							var $this = $( this ),
@@ -123,6 +123,13 @@
 
 							// If we have an editor
 							if ( the_editor ) {
+								// Focus the editor first
+								the_editor.focus();
+
+								// Move cursor to end of existing content (in the last child element)
+								the_editor.selection.select( editor.getBody().lastChild, true );
+								the_editor.selection.collapse( false );
+
 								// Trigger our custom focus event
 								the_editor.fire( 'note-editor-focus', data );
 							}
@@ -221,7 +228,7 @@
 							 *
 							 * Note: This is essentially the only method that we could use,
 							 * short of creating our own TinyMCE 4 theme (which there is little to
-							 * no documentation for), to remove the "inline" TinyMCE theme image toolbar.
+							 * no documentation for), to remove the "inlite" TinyMCE theme image toolbar.
 							 *
 							 * As of 06/01/18, TinyMCE does not currently provide us with a way
 							 * to grab a reference of panels or toolbars which belong to an editor.
@@ -310,8 +317,6 @@
 								}
 							} );
 						} );
-
-
 
 						// Editor initialization
 						editor.on( 'init', function() {

--- a/changelog.txt
+++ b/changelog.txt
@@ -2,9 +2,17 @@
 Plugin: Note
 Author: Slocum Design Studio
 Author URI: https://slocumstudio.com/
-Current Version: 1.4.6
+Current Version: 1.4.7
 ==========================================
 
+
+1.4.7 // June 06 2018
+---------------------
+- Fixed a bug where Note Widgets would lose focus while typing if the Customizer was not saved prior to editing
+- Adjusted CSS for Note TinyMCE insert media panel button (button now appears in the center of the toolbar)
+- Removed extra margin/padding CSS styles on Note Widget editors
+- Fixed a bug where non-standard Note Widget editors were not focused when the "Edit Content" button was
+  clicked during a Customizer session
 
 1.4.6 // June 01 2018
 ---------------------

--- a/includes/class-note-customizer.php
+++ b/includes/class-note-customizer.php
@@ -4,7 +4,7 @@
  *
  * @class Note_Customizer
  * @author Slocum Studio
- * @version 1.4.6
+ * @version 1.4.7
  * @since 1.0.0
  */
 
@@ -17,7 +17,7 @@ if ( ! class_exists( 'Note_Customizer' ) ) {
 		/**
 		 * @var string
 		 */
-		public $version = '1.4.6';
+		public $version = '1.4.7';
 
 		/**
 		 * @var array
@@ -860,7 +860,10 @@ if ( ! class_exists( 'Note_Customizer' ) ) {
 		 * This function enqueues scripts within the Customizer.
 		 */
 		public function customize_controls_enqueue_scripts() {
-			// Note Customizer
+			// Note Customizer Stylesheet
+			wp_enqueue_style( 'note-customizer', Note::plugin_url() . '/assets/css/note-customizer.css', array( 'customize-controls' ), Note::$version );
+
+			// Note Customizer Script
 			wp_enqueue_script( 'note-customizer', Note::plugin_url() . '/assets/js/note-customizer.js', array( 'customize-widgets' ), Note::$version, true );
 
 			// Setup Note Widget localize data

--- a/note.php
+++ b/note.php
@@ -3,7 +3,7 @@
  * Plugin Name: Note - A live edit text widget
  * Plugin URI: http://www.conductorplugin.com/note/
  * Description: Note is a simple and easy to use widget for editing bits of text, live, in your WordPress Customizer
- * Version: 1.4.6
+ * Version: 1.4.7
  * Author: Slocum Studio
  * Author URI: http://www.slocumstudio.com/
  * Requires at least: 4.3
@@ -26,7 +26,7 @@ if ( ! class_exists( 'Note' ) ) {
 		/**
 		 * @var string
 		 */
-		public static $version = '1.4.6';
+		public static $version = '1.4.7';
 
 		/**
 		 * @var Note, Instance of the class

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Donate link:
 Tags: note, widget, customizer, live edit, wysiwyg, text, text widget, plugin, sidebar
 Requires at least: 4.3
 Tested up to: 4.9.6
-Stable tag: 1.4.6
+Stable tag: 1.4.7
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -64,6 +64,12 @@ See the video in our [Description](https://wordpress.org/plugins/note/) for a li
 
 
 == Changelog ==
+
+= 1.4.7 // June 06 2018 =
+* Fixed a bug where Note Widgets would lose focus while typing if the Customizer was not saved prior to editing
+* Adjusted CSS for Note TinyMCE insert media panel button (button now appears in the center of the toolbar)
+* Removed extra margin/padding CSS styles on Note Widget editors
+* Fixed a bug where non-standard Note Widget editors were not focused when the "Edit Content" button was clicked during a Customizer session
 
 = 1.4.6 // June 01 2018 =
 * Transitioned to the "inline" TinyMCE theme (TinyMCE version 4.7 moved most of the TinyMCE UI logic into the theme instead of TinyMCE core)


### PR DESCRIPTION
- Fixed a bug where Note Widgets would lose focus while typing if the Customizer was not saved prior to editing
- Adjusted CSS for Note TinyMCE insert media panel button (button now appears in the center of the toolbar)
- Removed extra margin/padding CSS styles on Note Widget editors
- Fixed a bug where non-standard Note Widget editors were not focused when the "Edit Content" button was clicked during a Customizer session